### PR TITLE
[FEAT] 맞춤 공고 기능 추가

### DIFF
--- a/features/NoticeList/CustomNotice.tsx
+++ b/features/NoticeList/CustomNotice.tsx
@@ -1,42 +1,86 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Link from 'next/link';
 import Card from '@/shared/@common/notice/ui/Card';
-import { ItemData } from './AllNotice';
+import { Data, ItemData } from './AllNotice';
 import useFetch from '@/shared/@common/api/hooks/useFetch';
 import noticeAPI from '@/shared/@common/api/noticeAPI';
+import userAPI from '@/shared/@common/api/userAPI';
+import { jwtDecode } from 'jwt-decode';
 
 const CustomNotice = () => {
-  const { data, loading, error, execute } = useFetch(() => {
-    return noticeAPI.getNoticeList({});
-  });
+  if (typeof window !== 'undefined') {
+    const token = localStorage.getItem('token');
+    const decodedToken = token ? jwtDecode(token) : null;
+    const user = localStorage.getItem('user');
+    const userId = (decodedToken as any)?.userId || '';
 
-  return (
-    <>
+    const [noticeData, setNoticeData] = useState<Data>();
+    const [address, setAddress] = useState('');
+
+    const showNoticeData = async () => {
+      const noticeData = await noticeAPI.getNoticeList({ address: address });
+      setNoticeData(noticeData.data);
+    };
+
+    const { data, loading, error, execute } = useFetch(() => {
+      return userAPI.getUserData(userId);
+    });
+
+    useEffect(() => {
+      showNoticeData();
+    }, [userId]);
+    const userAddress = data && data.item.address;
+    console.log(noticeData);
+    return (
       <div className="flex w-full py-[60px] pc: px-auto flex-col items-center bg-purple-10 tracking-wide tablet:pl-8 tablet:items-start tablet:overflow-x-scroll tablet:whitespace-pre tablet:scrollbar-hide mobile:pl-3 mobile:overflow-x-scroll mobile:whitespace-pre mobile:scrollbar-hide mobile:items-start">
         <div className="flex flex-col gap-[31px] px-4">
-          <p className="text-[28px] font-bold">맞춤 공고</p>
+          <div className="text-[28px] font-bold">맞춤 공고</div>
           <div className="flex gap-4">
-            {data &&
-              data.items.length > 0 &&
-              data.items.slice(0, 3).map((item: ItemData) => (
-                <Link href={`/noticeInfo/${item.item.shop.item.id}`}>
-                  <Card
-                    name={item.item.shop.item.name}
-                    imageUrl={item.item.shop.item.imageUrl}
-                    address1={`${item.item.shop.item.address1} ${item.item.shop.item.address2}`}
-                    startsAt={item.item.startsAt}
-                    workhour={item.item.workhour}
-                    hourlyPay={item.item.hourlyPay}
-                    originalHourlyPay={item.item.shop.item.originalHourlyPay}
-                    closed={item.item.closed}
-                  />
-                </Link>
-              ))}
+            {userAddress && noticeData
+              ? noticeData.items.length > 0 &&
+                noticeData.items
+                  .filter(
+                    (item: ItemData) =>
+                      item.item.shop.item.address1 === userAddress,
+                  )
+                  .slice(0, 3)
+                  .map((item: ItemData) => (
+                    <Link href={`/noticeInfo/${item.item.shop.item.id}`}>
+                      <Card
+                        name={item.item.shop.item.name}
+                        imageUrl={item.item.shop.item.imageUrl}
+                        address1={`${item.item.shop.item.address1} ${item.item.shop.item.address2}`}
+                        startsAt={item.item.startsAt}
+                        workhour={item.item.workhour}
+                        hourlyPay={item.item.hourlyPay}
+                        originalHourlyPay={
+                          item.item.shop.item.originalHourlyPay
+                        }
+                        closed={item.item.closed}
+                      />
+                    </Link>
+                  ))
+              : noticeData &&
+                noticeData.items.length > 0 &&
+                noticeData.items.slice(0, 3).map((item: ItemData) => (
+                  <Link href={`/noticeInfo/${item.item.shop.item.id}`}>
+                    <Card
+                      name={item.item.shop.item.name}
+                      imageUrl={item.item.shop.item.imageUrl}
+                      address1={`${item.item.shop.item.address1} ${item.item.shop.item.address2}`}
+                      startsAt={item.item.startsAt}
+                      workhour={item.item.workhour}
+                      hourlyPay={item.item.hourlyPay}
+                      originalHourlyPay={item.item.shop.item.originalHourlyPay}
+                      closed={item.item.closed}
+                    />
+                  </Link>
+                ))}
           </div>
         </div>
       </div>
-    </>
-  );
+    );
+  }
 };
 
 export default CustomNotice;


### PR DESCRIPTION
## 🔥관련 이슈

- #96 

## :grin:주요 변경 사항

- [ ] 코드 리뷰 수정 사항 반영했습니다.
- 일반 회원 로그인 시 사용자 주소 맞춤 공고가 나오게 한다.
- 사장님 로그인 시 전체 공고 중 3개를 보여준다.
- 미로그인 시 전체 공고 중 3개를 보여준다.

## 📄스크린샷
![맞춤공고 설정](https://github.com/12-Pair-Programming/Dang-il/assets/144193370/1dc935c6-6b89-453e-869f-c979528006b6)


## :pencil:전달사항(세심하게 봐야 할 부분 / 고민점)

- 가끔 하이드레이션 오류가 발생하는 데 localstorage를 가져와서 그런 것 같습니다.
- 맞춤 공고에 지난 공고가 안 뜨게 해야합니다.
